### PR TITLE
add test cases for shib affiliation #8882

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibServiceBean.java
@@ -64,6 +64,8 @@ public class ShibServiceBean {
         UID_WITH_LEADING_SPACE,
         IDENTIFIER_WITH_LEADING_SPACE,
         MISSING_REQUIRED_ATTR,
+        ONE_AFFILIATION,
+        TWO_AFFILIATIONS,
     };
 
     public DevShibAccountType getDevShibAccountType() {
@@ -144,6 +146,14 @@ public class ShibServiceBean {
 
             case MISSING_REQUIRED_ATTR:
                 ShibUtil.mutateRequestForDevConstantMissingRequiredAttributes(request);
+                break;
+
+            case ONE_AFFILIATION:
+                ShibUtil.mutateRequestForDevConstantOneAffiliation(request);
+                break;
+
+            case TWO_AFFILIATIONS:
+                ShibUtil.mutateRequestForDevConstantTwoAffiliations(request);
                 break;
 
             default:

--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/shib/ShibUtil.java
@@ -261,6 +261,28 @@ public class ShibUtil {
         request.setAttribute(ShibUtil.usernameAttribute, "missing");
     }
 
+    static void mutateRequestForDevConstantOneAffiliation(HttpServletRequest request) {
+        request.setAttribute(ShibUtil.shibIdpAttribute, "https://fake.example.com/idp/shibboleth");
+        request.setAttribute(ShibUtil.uniquePersistentIdentifier, "oneAffiliation");
+        request.setAttribute(ShibUtil.firstNameAttribute, "Lurneen");
+        request.setAttribute(ShibUtil.lastNameAttribute, "Lumpkin");
+        request.setAttribute(ShibUtil.emailAttribute, "oneAffiliaton@mailinator.com");
+        request.setAttribute(ShibUtil.usernameAttribute, "oneAffiliaton");
+        // Affiliation. "ou" is the suggested attribute in :ShibAffiliationAttribute.
+        request.setAttribute("ou", "Beer-N-Brawl");
+    }
+
+    static void mutateRequestForDevConstantTwoAffiliations(HttpServletRequest request) {
+        request.setAttribute(ShibUtil.shibIdpAttribute, "https://fake.example.com/idp/shibboleth");
+        request.setAttribute(ShibUtil.uniquePersistentIdentifier, "twoAffiliatons");
+        request.setAttribute(ShibUtil.firstNameAttribute, "Lenny");
+        request.setAttribute(ShibUtil.lastNameAttribute, "Leonard");
+        request.setAttribute(ShibUtil.emailAttribute, "twoAffiliatons@mailinator.com");
+        request.setAttribute(ShibUtil.usernameAttribute, "twoAffiliatons");
+        // Affiliation. "ou" is the suggested attribute in :ShibAffiliationAttribute.
+        request.setAttribute("ou", "SNPP;Stonecutters");
+    }
+
     public static Map<String, String> getRandomUserStatic() {
         Map<String, String> fakeUser = new HashMap<>();
         String shortRandomString = UUID.randomUUID().toString().substring(0, 8);


### PR DESCRIPTION
This change is helping me test https://github.com/IQSS/dataverse/pull/8880 in a dev environment. That is, by testing this way I don't have to set up all of Shibboleth on a server.